### PR TITLE
Fix: remove link from queue cmd

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -138,8 +138,8 @@ async def queue_command(interaction: discord.Interaction):
         return
 
     lines = []
-    for index, (audio_url, title) in enumerate(list(queue), start=1):
-        lines.append(f"{index}. {title} - {audio_url}")
+    for index, (_audio_url, title) in enumerate(list(queue), start=1):
+        lines.append(f"{index}. {title}")
 
     message = "Queue:\n" + "\n".join(lines)
     await interaction.response.send_message(message)


### PR DESCRIPTION
URLs from yt are long and weird, probably not worth showing as it makes the command output messy (several lines)


<img width="891" height="489" alt="Screenshot 2025-10-13 at 10 47 34 AM" src="https://github.com/user-attachments/assets/39c2bc61-15c3-485f-8012-05901149f142" />


